### PR TITLE
feat(components): Add PartnerChallenge component

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
         "@radix-ui/react-label": "^2.1.0",
+        "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
         "@tanstack/react-table": "^8.20.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,13 @@ import Home from '@/pages/Home.tsx';
 import Login from '@/pages/Login.tsx';
 import { Route, Routes } from 'react-router-dom';
 import AuthRoute from './components/AuthRoute.tsx';
+import PartnerChallenge from './components/PartnerChallenge.tsx';
 import { APP_ROUTES_ENUM } from './main.tsx';
 import AllArticleCategories from './pages/Blog/AllArticleCategories.tsx';
 import Article from './pages/Blog/Article.tsx';
 import ArticleCategory from './pages/Blog/ArticleCategory.tsx';
 import Learn from './pages/Blog/Learn.tsx';
+import { challengeData } from './types/challengeType.ts';
 
 function App() {
     const { os } = useDeviceDetection();
@@ -40,12 +42,16 @@ function App() {
                 <Routes>
                     <Route element={<AuthRoute />}>
                         <Route element={<BankCheck />}>
+                            <Route path={APP_ROUTES_ENUM.LEARN} element={<Learn />} />
                             <Route path={APP_ROUTES_ENUM.HOME} element={<Home />} />
                         </Route>
                     </Route>
                     <Route element={<PublicRoute />}>
-                        <Route path={APP_ROUTES_ENUM.LEARN} element={<Learn />} />
                         <Route path={`${APP_ROUTES_ENUM.ARTICLE}/:id`} element={<Article />} />
+                        <Route
+                            path={`${APP_ROUTES_ENUM.TEST}`}
+                            element={<PartnerChallenge challenge={challengeData} />}
+                        />
                         <Route path={`${APP_ROUTES_ENUM.ARTICLE_CATEGORIES}`} element={<AllArticleCategories />} />
                         <Route path={`${APP_ROUTES_ENUM.ARTICLE_CATEGORY}/:id`} element={<ArticleCategory />} />
                         <Route path={APP_ROUTES_ENUM.LOGIN} element={<Login VITE_GOOGLE_CLIENT_ID={googleId} />} />

--- a/src/components/PartnerChallenge.tsx
+++ b/src/components/PartnerChallenge.tsx
@@ -1,0 +1,98 @@
+import { Progress } from '@/components/ui/progress';
+import { challengeType } from '@/types/challengeType';
+import { createUseStyles } from 'react-jss';
+
+type PartnerChallengeProps = {
+    challenge: challengeType;
+};
+
+// Le nombre de progression est fixe pour le moment
+// pareil pour le nombre total de défis réalisés
+
+const PartnerChallenge = (props: PartnerChallengeProps) => {
+    const styles = useStyles();
+    return (
+        <div className={styles.wrapper}>
+            <div className={styles.leftPart} style={{ backgroundImage: `url(${props.challenge.image})` }}>
+                <div className={styles.categoryIcon}>
+                    <img
+                        className={styles.icon}
+                        src={props.challenge.category.icon}
+                        alt={props.challenge.category.title}
+                    />
+                </div>
+            </div>
+            <div className={styles.rightPart}>
+                <h6 className={styles.challengeTitle}>{props.challenge.title}</h6>
+                <p className={styles.challengeDesc}>{props.challenge.description}</p>
+                <div className={styles.progressBar}>
+                    <Progress value={66} />
+                </div>
+                <p className={styles.challengeProgression}>05/41</p>
+            </div>
+        </div>
+    );
+};
+
+export default PartnerChallenge;
+
+const useStyles = createUseStyles({
+    wrapper: {
+        backgroundColor: '#FFF',
+        width: '100%',
+        height: '100%',
+        borderRadius: '20px',
+        display: 'flex',
+        gap: '12px',
+        flexDirection: 'row',
+        border: '1px solid #4361EE',
+    },
+    leftPart: {
+        width: '30%',
+        borderRadius: '20px',
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+    },
+    categoryIcon: {
+        height: '20px',
+        width: '20px',
+        borderRadius: '50%',
+        backgroundColor: '#D9D9D9',
+        margin: '15px',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    icon: {
+        width: '12px',
+        height: '12px',
+    },
+    rightPart: {
+        width: '70%',
+        paddingRight: '50px',
+    },
+    challengeTitle: {
+        paddingTop: '20px',
+        paddingBottom: '13px',
+        fontSize: '14px',
+        lineHeight: '1.2',
+        fontWeight: '700',
+    },
+    challengeDesc: {
+        fontSize: '9px',
+        fontWeight: '400',
+        color: '#535353',
+        paddingBottom: '20px',
+        lineHeight: '1.2',
+    },
+    progressBar: {
+        paddingBottom: '18px',
+    },
+    challengeProgression: {
+        fontWeight: '700',
+        color: '#000000',
+        fontSize: '10px',
+        textAlign: 'right',
+        paddingBottom: '14px',
+    },
+});

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import * as ProgressPrimitive from '@radix-ui/react-progress';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Progress = React.forwardRef<
+    React.ElementRef<typeof ProgressPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+    <ProgressPrimitive.Root
+        ref={ref}
+        className={cn('relative h-2 w-full overflow-hidden rounded-full bg-secondary', className)}
+        {...props}
+    >
+        <ProgressPrimitive.Indicator
+            className='h-full w-full flex-1 bg-primary transition-all'
+            style={{ transform: `translateX(-${100 - (value || 0)}%)`, backgroundColor: '#4361EE' }}
+        />
+    </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ export const APP_ROUTES_ENUM = {
     ARTICLE_CATEGORIES: '/article-categories',
     ARTICLE_CATEGORY: '/article-category',
     LOGIN: '/login',
+    TEST: '/test',
 };
 
 const container = document.getElementById('root');

--- a/src/types/challengeType.ts
+++ b/src/types/challengeType.ts
@@ -1,0 +1,54 @@
+import { categoriesEnum, categoryType, subjectType } from "@/temp/BlogData"
+import { TransactionType } from "@/types/transactionType"
+
+export type enterpriseType = {
+    id:number,
+    name:string,
+    logo:string,
+    description:string,
+    creation_date:Date,
+    challenge: challengeType[],
+}
+
+export type userType = {
+    id:number,
+    username:string,
+    password:string,
+    powens_token:string,
+    transactions: TransactionType[],
+    friends: userType[],
+    articles: subjectType[],
+    likedArticles: subjectType[],
+    challenges: challengeType[],
+}
+
+export type challengeType = {
+    id:number,
+    title:string,
+    description:string,
+    image:string,
+    entreprise: enterpriseType,
+    category: categoryType,
+    users: userType[],
+}
+
+export const challengeData:challengeType = {
+    id:1,
+    title:"Challenge 1",
+    description:"Description 1",
+    image:"Image 1",
+    entreprise: {
+        id:1,
+        name:"Enterprise 1",
+        logo:"Logo 1",
+        description:"Description 1",
+        creation_date:new Date(),
+        challenge: [],
+    },
+    category: {
+        id:1,
+        title:categoriesEnum.BUDGET,
+        icon:'https://via.placeholder.com/150',
+    },
+    users: [],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,14 @@
   dependencies:
     "@radix-ui/react-slot" "1.1.0"
 
+"@radix-ui/react-progress@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-progress/-/react-progress-1.1.0.tgz#28c267885ec154fc557ec7a66cb462787312f7e2"
+  integrity sha512-aSzvnYpP725CROcxAOEBVZZSIQVQdHgBr2QQFKySsaD14u8dNT0batuXI+AAGDdAHfXH8rbnHmjYFqVJ21KkRg==
+  dependencies:
+    "@radix-ui/react-context" "1.1.0"
+    "@radix-ui/react-primitive" "2.0.0"
+
 "@radix-ui/react-roving-focus@1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.0.tgz"
@@ -2148,7 +2156,7 @@ elementtree@^0.1.7:
     commitizen "^4.3.0"
     confettis "^0.3.4"
     date-fns "^3.6.0"
-    elios_frontend "file:../../../../Library/Caches/Yarn/v6/npm-elios-frontend-0.0.0-495ab5e9-3961-4ec5-8584-88f8cda6df93-1727280722647/node_modules/elios_frontend"
+    elios_frontend "file:../../../Library/Caches/Yarn/v6/npm-elios-frontend-0.0.0-abbeca7c-adfc-48b3-87a2-192457344009-1731074316916/node_modules/elios_frontend"
     embla-carousel "^8.3.0"
     embla-carousel-react "^8.3.0"
     gapi-script "^1.2.0"


### PR DESCRIPTION
This pull request introduces a new feature to display partner challenges in the application. It includes updates to routing, new components, and type definitions.

**New feature implementation:**

* Added a new component `PartnerChallenge` to display partner challenge details, including progress and description.
* Introduced a `Progress` component to visually represent challenge progress.

**Routing updates:**

* Updated `src/App.tsx` to include the new `PartnerChallenge` component in the routes. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R9-R15) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R45-R54)
* Added a new route `TEST` to `APP_ROUTES_ENUM` for the partner challenge.

**Type definitions:**

* Defined new types for `challengeType`, `enterpriseType`, and `userType` in `src/types/challengeType.ts` to support the partner challenge data structure.

**Dependency updates:**

* Added `@radix-ui/react-progress` to `package.json` to support the new progress component.